### PR TITLE
Available remove row function not working if cursor is in cell. 

### DIFF
--- a/src/js/TableTrick.js
+++ b/src/js/TableTrick.js
@@ -369,7 +369,7 @@ export default class TableTrick {
         const tr = td.parent;
         manageMergedCells(tr.domNode);
         TableHistory.register('remove', { node: tr.domNode, nextNode: tr.next ? tr.next.domNode : null, parentNode: tr.parent.domNode });
-        const _tr = Parchment.find(tr);
+        const _tr = Parchment.find(tr.domNode);
         if (_tr) { // remove node this way in order to update delta
           _tr.remove();
         }


### PR DESCRIPTION
All of table functions in the edit menu can be used if the cursor is in the table cell. However it seems that the remove row function doesnt seem to work in the same fashion. Upon some review I noticed the parchment.find function at 372 didn't get domNode of the tr to do the find. That seemed to fix the issue. Can delete row with selection or cursor inside cell.