### PR TITLE
New feature: hide table border

### DIFF
--- a/src/css/quill.table.css
+++ b/src/css/quill.table.css
@@ -14,6 +14,10 @@
   white-space: pre-wrap; /* https://github.com/quilljs/quill/issues/1760 */
 }
 
+.ql-editor__table--hideBorder td {
+  border: none !important;
+}
+
 .ql-editor table td[rowspan="2"] {
   height: 50px;
 }
@@ -146,6 +150,14 @@
 
 .ql-picker-item[data-value="remove-table"]:before {
   content: "Remove table";
+}
+
+.ql-picker-item[data-value="hide-border"]::after {
+  content: "Hide Border";
+}
+
+.ql-picker-item[data-value="show-border"]::after {
+  content: "Show Border";
 }
 
 .ql-table:nth-of-type(1),

--- a/src/demo.js
+++ b/src/demo.js
@@ -29,6 +29,8 @@ const defaultToolbar = [
         'merge-selection',
         'remove-cell',
         'remove-selection',
+        'hide-border',
+        'show-border',
         'undo',
         'redo'
       ]

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import TableTrick from './js/TableTrick';
 import TableSelection from './js/TableSelection';
 import TableToolbar from './js/TableToolbar';
 import './css/quill.table.css';
+import { hiddenBorderClassName } from './js/TableTrick';
 let Container = Quill.import('blots/container');
 
 const Parchment = Quill.import('parchment');
@@ -111,7 +112,8 @@ export default class TableModule {
           node.getAttribute('cell_id'),
           node.getAttribute('merge_id'),
           node.getAttribute('colspan'),
-          node.getAttribute('rowspan')
+          node.getAttribute('rowspan'),
+          tableNode.classList.contains(hiddenBorderClassName) //is the table hidden?
         ].join('|')
       }));
     });

--- a/src/js/TableBlot.js
+++ b/src/js/TableBlot.js
@@ -3,6 +3,7 @@ import TableTrick from './TableTrick';
 import TableRow from './TableRowBlot';
 import TableHistory from './TableHistory';
 import ContainBlot from './ContainBlot';
+import { hiddenBorderClassName } from './TableTrick';
 
 const Parchment = Quill.import('parchment');
 
@@ -10,8 +11,12 @@ class Table extends ContainBlot {
   static create(value) {
     const tagName = 'table';
     let node = super.create(tagName);
-    node.setAttribute('table_id', value ? value : TableTrick.random_id());
-    return node;
+    let atts = value.split('|');
+    node.setAttribute('table_id', atts[0]);
+    if (atts[1] && JSON.parse(atts[1]) === true){
+      node.classList.add(hiddenBorderClassName)
+    }
+    return node
   }
 
   format() {}

--- a/src/js/TableCellBlot.js
+++ b/src/js/TableCellBlot.js
@@ -8,20 +8,22 @@ const Parchment = Quill.import('parchment');
 
 class TableCell extends ContainBlot {
   static create(value) {
-    const tagName = 'td';
-    let node = super.create(tagName);
-    let ids = value.split('|');
-    node.setAttribute('table_id', ids[0]);
-    node.setAttribute('row_id', ids[1]);
-    node.setAttribute('cell_id', ids[2]);
-    if (ids[3]) {
-      node.setAttribute('merge_id', ids[3]);
+    let node = super.create();
+    let atts = value.split('|');
+    node.setAttribute('table_id', atts[0]);
+    node.setAttribute('row_id', atts[1]);
+    node.setAttribute('cell_id', atts[2]);
+    if (atts[3]) {
+      node.setAttribute('merge_id', atts[3]);
     }
-    if (ids[4]) {
-      node.setAttribute('colspan', ids[4]);
+    if (atts[4]) {
+      node.setAttribute('colspan', atts[4]);
     }
-    if (ids[5]) {
-      node.setAttribute('rowspan', ids[5]);
+    if (atts[5]) {
+      node.setAttribute('rowspan', atts[5]);
+    }
+    if(atts[6]){
+      node.setAttribute('hide_border', atts[6]);
     }
     return node;
   }
@@ -38,7 +40,8 @@ class TableCell extends ContainBlot {
           this.domNode.getAttribute('cell_id'),
           this.domNode.getAttribute('merge_id'),
           this.domNode.getAttribute('colspan'),
-          this.domNode.getAttribute('rowspan')
+          this.domNode.getAttribute('rowspan'),
+          this.domNode.getAttribute('hide_border') //is the hide class present in the table.. index.js 116, TD cell matcher
         ].join('|')
     }
   }
@@ -56,7 +59,8 @@ class TableCell extends ContainBlot {
         // we will mark td position, put in table and replace mark
         let mark = Parchment.create('block');
         this.parent.insertBefore(mark, this.next);
-        let table = Parchment.create('table', this.domNode.getAttribute('table_id'));
+        let table = Parchment.create('table', this.domNode.getAttribute('table_id') + '|' + this.domNode.getAttribute('hide_border'));
+        this.domNode.removeAttribute('hide_border'); //no longer need this once we set it in the table, since blots created from cell to table. 
         let tr = Parchment.create('tr', this.domNode.getAttribute('row_id'));
         table.appendChild(tr);
         tr.appendChild(this);

--- a/src/js/TableHistory.js
+++ b/src/js/TableHistory.js
@@ -190,7 +190,7 @@ class TableHistory {
   static propertyChange(change, revert) {
     const { node, property, oldValue, newValue } = change;
     const value = revert ? oldValue : newValue;
-    if (value !== null) {
+    if (value) {
       node.setAttribute(property, value);
     } else {
       node.removeAttribute(property);

--- a/src/js/TableSelection.js
+++ b/src/js/TableSelection.js
@@ -1,4 +1,5 @@
 import TableToolbar from './TableToolbar';
+import { hiddenBorderClassName } from './TableTrick';
 
 class TableSelection {
   static focusedCell = null;
@@ -108,7 +109,9 @@ class TableSelection {
     if (TableSelection.selectionStartElement || TableSelection.selectionEndElement) {
       // there is a table selection
       isInTable = true;
-      TableToolbar.enable(quill, ['split-cell', 'merge-selection', 'remove-selection']);
+      TableToolbar.enable(quill, ['split-cell', 'merge-selection', 'remove-selection', TableSelection.selectionStartElement.closest('table').classList.contains(hiddenBorderClassName)?'show-border':'hide-border'] );
+      //disable selection based on hidden class
+      TableToolbar.disable(quill, !TableSelection.selectionStartElement.closest('table').classList.contains(hiddenBorderClassName)?'show-border':'hide-border'); 
     } else {
       // Text selection
       TableToolbar.disable(quill, ['split-cell', 'merge-selection', 'remove-selection']);

--- a/src/js/TableTrick.d.ts
+++ b/src/js/TableTrick.d.ts
@@ -15,6 +15,7 @@ export default class TableTrick {
     static removeSelection(quill: any): void;
     static _removeCell(cell: any, recursive?: boolean): boolean;
     static _split(cell: any): boolean;
+    static borderToggle(quill: any, hide:boolean): void;
     static emitTextChange(quill: any, oldDelta: any, source?: string): void;
     static table_handler(value: any, quill: any): boolean;
 }


### PR DESCRIPTION
Add a new feature for hiding table border. Toggle menu item within the option menu. Hiding is also a undoable/redoable property change. We use hidden tables to organized column data.

Within the feature we can also resurrect tables that start with the hidden class.

Since we start table construction from cell to table within the blots, you'll see matcher will contain whether the table element brought in contains the hidden class. in the blot you'll see we utilize it when we start a table up in the blot.

Toolbar recognizes a table border has been shown or hidden and shows the user the appropriate toggle.

Everything seemed to test and work very well. Let me know if this also looks good on your end and/or you have suggestions.