### PR TITLE
One thing i forgot for hide and show

### DIFF
--- a/src/js/TableSelection.js
+++ b/src/js/TableSelection.js
@@ -155,6 +155,16 @@ class TableSelection {
       quill.table.isInTable = true;
       TableToolbar.enable(quill, ['append-row*', 'append-col*', 'remove-cell', 'remove-row', 'remove-col', 'remove-table']);
     }
+
+    let cursoredSelection = quill.getSelection();
+    if (isInTable && quill.table.isInTable && cursoredSelection) { //we are in table with a cursoredSelection
+      const [cursoredElement] = quill.getLine(cursoredSelection.index);
+      let cursoredTable = cursoredElement.domNode.closest('table');
+      if (cursoredTable){
+        TableToolbar.enable(quill, [cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);
+        TableToolbar.disable(quill, [!cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);   
+      }
+    }
   }
 
   static getSelectionCoords() {

--- a/src/js/TableSelection.js
+++ b/src/js/TableSelection.js
@@ -22,15 +22,14 @@ class TableSelection {
       // do nothing with center or right click
       return;
     }
-
+    
+    // reset cell selection, even if it is cursor click, keeps everyone in check
+    TableSelection.previousSelection = [TableSelection.selectionStartElement, TableSelection.selectionEndElement];
+    TableSelection.selectionStartElement = TableSelection.selectionEndElement = null;
     TableSelection.resetSelection();
 
     if ((!TableSelection.cellSelectionOnClick && e.ctrlKey) || TableSelection.cellSelectionOnClick){
       TableSelection.isMouseDown = true;
-      // reset cell selection
-      TableSelection.previousSelection = [TableSelection.selectionStartElement, TableSelection.selectionEndElement];
-      TableSelection.selectionStartElement = TableSelection.selectionEndElement = null;
-      TableSelection.resetSelection();
 
       const targetCell = TableSelection.getTargetCell(e);
       if (!targetCell) {
@@ -156,13 +155,16 @@ class TableSelection {
       TableToolbar.enable(quill, ['append-row*', 'append-col*', 'remove-cell', 'remove-row', 'remove-col', 'remove-table']);
     }
 
-    let cursoredSelection = quill.getSelection();
-    if (isInTable && quill.table.isInTable && cursoredSelection) { //we are in table with a cursoredSelection
-      const [cursoredElement] = quill.getLine(cursoredSelection.index);
-      let cursoredTable = cursoredElement.domNode.closest('table');
-      if (cursoredTable){
-        TableToolbar.enable(quill, [cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);
-        TableToolbar.disable(quill, [!cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);   
+    if (isInTable && quill.table.isInTable){ //we are in a table, are we cursored?
+      let cursoredSelection = quill.getSelection();
+
+      if (cursoredSelection) { //we are in table with a cursoredSelection
+        const [cursoredElement] = quill.getLine(cursoredSelection.index);
+        let cursoredTable = cursoredElement.domNode.closest('table');
+        if (cursoredTable){
+          TableToolbar.enable(quill, [cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);
+          TableToolbar.disable(quill, [!cursoredTable.classList.contains(hiddenBorderClassName)?'show-border':'hide-border']);   
+        }
       }
     }
   }


### PR DESCRIPTION
Thanks for merging the PR feature for show and hide table. In our case we don't use the single click select case (aka using ctrl if we had to select), instead we use the click that cursors into a cell directly. That didn't fire the show/hide feature how we wanted. Now the user can fire this feature just like add/remove columns/ rows, etc if you are cursor'd into a cell.  I made a small change in TableSelection to reset table cell selection whether its a cursor in or select, so that we target the right cell and feature not just for hide/show border. If you selected one cell in another table and cursored to another the selected would take the priority and never get reset. 

This and the rest of the edit features seem to work as intended with what's available for whatever workflow whether it's selection or cursor'd in. 

Thanks again for the continued upkeep and merging. 